### PR TITLE
심영인 seminar1 과제

### DIFF
--- a/src/main/kotlin/WebConfig.kt
+++ b/src/main/kotlin/WebConfig.kt
@@ -1,17 +1,18 @@
 package com.wafflestudio.seminar.spring2023
 
-import com.wafflestudio.seminar.spring2023.user.service.AuthenticateException
-import com.wafflestudio.seminar.spring2023.user.service.Authenticated
-import com.wafflestudio.seminar.spring2023.user.service.User
-import com.wafflestudio.seminar.spring2023.user.service.UserService
+import com.wafflestudio.seminar.spring2023.user.service.*
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.MethodParameter
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import kotlin.RuntimeException
 
 
 @Configuration
@@ -53,4 +54,26 @@ class UserArgumentResolver(
             }
         }
     }
+}
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserException::class)
+    fun handleUserException(e: UserException): ResponseEntity<Unit> {
+        val status = when (e) {
+            is SignUpBadUsernameException, is SignUpBadPasswordException -> 400
+            is SignUpUsernameConflictException -> 409
+            is SignInUserNotFoundException, is SignInInvalidPasswordException -> 404
+            is AuthenticateException -> 401
+        }
+
+        return ResponseEntity.status(status).build()
+    }
+
+    @ExceptionHandler(RuntimeException::class)
+    fun handleRuntimeException(e: RuntimeException): ResponseEntity<Unit> {
+        return ResponseEntity.status(500).build()
+    }
+
 }

--- a/src/main/kotlin/WebConfig.kt
+++ b/src/main/kotlin/WebConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import kotlin.RuntimeException
 
 
 @Configuration

--- a/src/main/kotlin/common/SimpleCache.kt
+++ b/src/main/kotlin/common/SimpleCache.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.seminar.spring2023.common
+
+import java.time.Instant
+
+/**
+ * 캐시 구현체. TTL 10초 후 만료되는 간단한 Lookup 용 캐시.
+ */
+class SimpleCache<K, V> {
+
+    companion object {
+        private const val TTL = 10
+    }
+
+    private val cacheMap: HashMap<K, Item> = HashMap()
+
+    /**
+     * 캐시 조회.
+     * 
+     * 캐시 Miss시 [block] 실행 값을 캐싱하고 리턴한다.
+     */
+    fun get(key: K, block: () -> V): V {
+        val item = cacheMap[key]
+        if (item != null && !item.isExpired()) {
+            return item.value
+        }
+        val value = block()
+        cacheMap[key] = Item(value)
+        return value
+    }
+
+    /**
+     * TTL 정보를 담고 있는 캐시 Value.
+     */
+    private inner class Item(val value: V) {
+
+        private val createdAt = Instant.now().epochSecond
+
+        /**
+         * [TTL]이 지난 경우 True를 리턴.
+         */
+        fun isExpired(): Boolean = (Instant.now().epochSecond - createdAt) > TTL
+
+    }
+
+}

--- a/src/main/kotlin/playlist/controller/PlaylistController.kt
+++ b/src/main/kotlin/playlist/controller/PlaylistController.kt
@@ -49,8 +49,13 @@ class PlaylistController(
 
     @ExceptionHandler
     fun handleException(e: PlaylistException): ResponseEntity<Unit> {
-        TODO()
+        val status = when (e) {
+            is PlaylistNotFoundException -> 404 
+            is PlaylistAlreadyLikedException, is PlaylistNeverLikedException -> 403
+        } 
+        return ResponseEntity.status(status).build()
     }
+    
 }
 
 data class PlaylistGroupsResponse(val groups: List<PlaylistGroup>)

--- a/src/main/kotlin/playlist/controller/PlaylistController.kt
+++ b/src/main/kotlin/playlist/controller/PlaylistController.kt
@@ -1,24 +1,21 @@
 package com.wafflestudio.seminar.spring2023.playlist.controller
 
-import com.wafflestudio.seminar.spring2023.playlist.service.Playlist
-import com.wafflestudio.seminar.spring2023.playlist.service.PlaylistException
-import com.wafflestudio.seminar.spring2023.playlist.service.PlaylistGroup
+import com.wafflestudio.seminar.spring2023.playlist.service.*
 import com.wafflestudio.seminar.spring2023.user.service.Authenticated
 import com.wafflestudio.seminar.spring2023.user.service.User
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
-class PlaylistController {
+class PlaylistController(
+    private val playlistService: PlaylistService,
+    private val playlistLikesService: PlaylistLikeService,
+) {
 
     @GetMapping("/api/v1/playlist-groups")
     fun getPlaylistGroup(): PlaylistGroupsResponse {
-        TODO()
+        val groups = playlistService.getGroups()
+        return PlaylistGroupsResponse(groups)
     }
 
     @GetMapping("/api/v1/playlists/{id}")
@@ -26,7 +23,12 @@ class PlaylistController {
         @PathVariable id: Long,
         user: User?,
     ): PlaylistResponse {
-        TODO()
+        val playlist = playlistService.get(id)
+        val isLiked = when (user) {
+            null -> false
+            else -> playlistLikesService.exists(id, user.id)
+        }
+        return PlaylistResponse(playlist, isLiked)
     }
 
     @PostMapping("/api/v1/playlists/{id}/likes")
@@ -34,7 +36,7 @@ class PlaylistController {
         @PathVariable id: Long,
         @Authenticated user: User,
     ) {
-        TODO()
+        playlistLikesService.create(id, user.id)
     }
 
     @DeleteMapping("/api/v1/playlists/{id}/likes")
@@ -42,7 +44,7 @@ class PlaylistController {
         @PathVariable id: Long,
         @Authenticated user: User,
     ) {
-        TODO()
+        playlistLikesService.delete(id, user.id)
     }
 
     @ExceptionHandler

--- a/src/main/kotlin/playlist/controller/PlaylistController.kt
+++ b/src/main/kotlin/playlist/controller/PlaylistController.kt
@@ -50,12 +50,13 @@ class PlaylistController(
     @ExceptionHandler
     fun handleException(e: PlaylistException): ResponseEntity<Unit> {
         val status = when (e) {
-            is PlaylistNotFoundException -> 404 
-            is PlaylistAlreadyLikedException, is PlaylistNeverLikedException -> 403
-        } 
+            is PlaylistNotFoundException -> 404
+            is PlaylistAlreadyLikedException, is PlaylistNeverLikedException -> 409
+        }
+
         return ResponseEntity.status(status).build()
     }
-    
+
 }
 
 data class PlaylistGroupsResponse(val groups: List<PlaylistGroup>)

--- a/src/main/kotlin/playlist/repository/PlaylistEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import jakarta.persistence.*
+
+@Entity(name = "playlists")
+class PlaylistEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val title: String,
+    val subtitle: String,
+    val image: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    val playlistGroup: PlaylistGroupEntity,
+    @OneToMany(mappedBy = "playlist")
+    val songs: MutableList<PlaylistSongsEntity>,
+    @OneToMany(mappedBy = "playlist")
+    val likeUsers: List<PlaylistLikesEntity>,
+)

--- a/src/main/kotlin/playlist/repository/PlaylistGroupEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistGroupEntity.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import jakarta.persistence.*
+
+@Entity(name = "playlist_groups")
+class PlaylistGroupEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val title: String,
+    val open: Boolean,
+    @OneToMany(mappedBy = "playlistGroup")
+    val playlists: List<PlaylistEntity>
+)

--- a/src/main/kotlin/playlist/repository/PlaylistGroupRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistGroupRepository.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface PlaylistGroupRepository : JpaRepository<PlaylistGroupEntity, Long> {
+    @Query("SELECT pg FROM playlist_groups pg LEFT JOIN FETCH pg.playlists p WHERE pg.open = TRUE AND SIZE(p) > 0")
+    fun findAllWithJoinFetch(): List<PlaylistGroupEntity>
+}

--- a/src/main/kotlin/playlist/repository/PlaylistLikesEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistLikesEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import com.wafflestudio.seminar.spring2023.user.repository.UserEntity
+import jakarta.persistence.*
+
+@Entity(name = "playlist_likes")
+class PlaylistLikesEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @ManyToOne
+    @JoinColumn(name = "playlist_id")
+    val playlist: PlaylistEntity,
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    val user: UserEntity,
+)

--- a/src/main/kotlin/playlist/repository/PlaylistLikesRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistLikesRepository.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlaylistLikesRepository : JpaRepository<PlaylistLikesEntity, Long> {
+
+    fun existsByPlaylistIdAndUserId(playlistId: Long, userId: Long): Boolean
+
+    fun deleteByPlaylistIdAndUserId(playlistId: Long, userId: Long)
+
+}

--- a/src/main/kotlin/playlist/repository/PlaylistRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistRepository.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface PlaylistRepository : JpaRepository<PlaylistEntity, Long> {
+    @Query("SELECT p FROM playlists p LEFT JOIN FETCH p.songs ps LEFT JOIN FETCH ps.song s WHERE p.id = :id")
+    fun findByIdWithJoinFetch(id: Long): PlaylistEntity?
+}

--- a/src/main/kotlin/playlist/repository/PlaylistRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface PlaylistRepository : JpaRepository<PlaylistEntity, Long> {
-    @Query("SELECT p FROM playlists p LEFT JOIN FETCH p.songs ps LEFT JOIN FETCH ps.song s WHERE p.id = :id")
+    @Query("SELECT p FROM playlists p LEFT JOIN FETCH p.songs WHERE p.id = :id")
     fun findByIdWithJoinFetch(id: Long): PlaylistEntity?
 }

--- a/src/main/kotlin/playlist/repository/PlaylistSongsEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistSongsEntity.kt
@@ -11,7 +11,7 @@ class PlaylistSongsEntity(
     @ManyToOne
     @JoinColumn(name = "playlist_id")
     val playlist: PlaylistEntity,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "song_id")
     val song: SongEntity,
 )

--- a/src/main/kotlin/playlist/repository/PlaylistSongsEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistSongsEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
+import jakarta.persistence.*
+
+@Entity(name = "playlist_songs")
+class PlaylistSongsEntity(
+    @Id
+    @GeneratedValue
+    val id: Long = 0L,
+    @ManyToOne
+    @JoinColumn(name = "playlist_id")
+    val playlist: PlaylistEntity,
+    @ManyToOne
+    @JoinColumn(name = "song_id")
+    val song: SongEntity,
+)

--- a/src/main/kotlin/playlist/service/Playlist.kt
+++ b/src/main/kotlin/playlist/service/Playlist.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistEntity
 import com.wafflestudio.seminar.spring2023.song.service.Song
+import com.wafflestudio.seminar.spring2023.song.service.toSong
 
 data class Playlist(
     val id: Long,
@@ -8,4 +10,14 @@ data class Playlist(
     val subtitle: String,
     val image: String,
     val songs: List<Song>,
-)
+) {
+
+    constructor(entity: PlaylistEntity) : this(
+        id = entity.id,
+        title = entity.title,
+        subtitle = entity.subtitle,
+        image = entity.image,
+        songs = entity.songs.map { it.song.toSong() }
+    )
+
+}

--- a/src/main/kotlin/playlist/service/Playlist.kt
+++ b/src/main/kotlin/playlist/service/Playlist.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
 import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistEntity
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
 import com.wafflestudio.seminar.spring2023.song.service.Song
 import com.wafflestudio.seminar.spring2023.song.service.toSong
 
@@ -12,12 +13,12 @@ data class Playlist(
     val songs: List<Song>,
 ) {
 
-    constructor(entity: PlaylistEntity) : this(
-        id = entity.id,
-        title = entity.title,
-        subtitle = entity.subtitle,
-        image = entity.image,
-        songs = entity.songs.map { it.song.toSong() }
+    constructor(playlistEntity: PlaylistEntity, songEntities: List<SongEntity>) : this(
+        id = playlistEntity.id,
+        title = playlistEntity.title,
+        subtitle = playlistEntity.subtitle,
+        image = playlistEntity.image,
+        songs = songEntities.map(SongEntity::toSong)
     )
 
 }

--- a/src/main/kotlin/playlist/service/PlaylistBrief.kt
+++ b/src/main/kotlin/playlist/service/PlaylistBrief.kt
@@ -1,8 +1,19 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistEntity
+
 data class PlaylistBrief(
     val id: Long,
     val title: String,
     val subtitle: String,
     val image: String,
-)
+) {
+
+    constructor(entity: PlaylistEntity) : this(
+        id = entity.id,
+        title = entity.title,
+        subtitle = entity.subtitle,
+        image = entity.image
+    )
+
+}

--- a/src/main/kotlin/playlist/service/PlaylistGroup.kt
+++ b/src/main/kotlin/playlist/service/PlaylistGroup.kt
@@ -1,7 +1,17 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistGroupEntity
+
 data class PlaylistGroup(
     val id: Long,
     val title: String,
     val playlists: List<PlaylistBrief>,
-)
+) {
+
+    constructor(entity: PlaylistGroupEntity) : this(
+        id = entity.id,
+        title = entity.title,
+        playlists = entity.playlists.map { PlaylistBrief(it) }
+    )
+
+}

--- a/src/main/kotlin/playlist/service/PlaylistLikeServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistLikeServiceImpl.kt
@@ -1,19 +1,40 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistLikesEntity
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistLikesRepository
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistRepository
+import com.wafflestudio.seminar.spring2023.user.repository.UserRepository
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
 @Service
-class PlaylistLikeServiceImpl : PlaylistLikeService {
+class PlaylistLikeServiceImpl(
+    private val playlistRepository: PlaylistRepository,
+    private val userRepository: UserRepository,
+    private val playlistLikesRepository: PlaylistLikesRepository,
+) : PlaylistLikeService {
 
     override fun exists(playlistId: Long, userId: Long): Boolean {
-        TODO()
+        return playlistLikesRepository.existsByPlaylistIdAndUserId(playlistId, userId)
     }
 
     override fun create(playlistId: Long, userId: Long) {
-        TODO()
+        val playlist = playlistRepository.findByIdWithJoinFetch(playlistId) ?: throw PlaylistNotFoundException()
+
+        if (exists(playlistId, userId)) {
+            throw PlaylistAlreadyLikedException()
+        }
+
+        val user = userRepository.findById(userId).get()
+        playlistLikesRepository.save(PlaylistLikesEntity(playlist = playlist, user = user))
     }
 
+    @Transactional
     override fun delete(playlistId: Long, userId: Long) {
-        TODO()
+        if (!exists(playlistId, userId)) {
+            throw PlaylistNeverLikedException()
+        }
+        playlistLikesRepository.deleteByPlaylistIdAndUserId(playlistId, userId)
     }
+
 }

--- a/src/main/kotlin/playlist/service/PlaylistLikeServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistLikeServiceImpl.kt
@@ -31,9 +31,12 @@ class PlaylistLikeServiceImpl(
 
     @Transactional
     override fun delete(playlistId: Long, userId: Long) {
+        playlistRepository.findByIdWithJoinFetch(playlistId) ?: throw PlaylistNotFoundException()
+
         if (!exists(playlistId, userId)) {
             throw PlaylistNeverLikedException()
         }
+
         playlistLikesRepository.deleteByPlaylistIdAndUserId(playlistId, userId)
     }
 

--- a/src/main/kotlin/playlist/service/PlaylistServiceCacheImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistServiceCacheImpl.kt
@@ -1,18 +1,30 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.common.SimpleCache
+import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 
 // TODO: 캐시 TTL이 10초가 되도록 캐시 구현체를 구현 (추가 과제)
+@Primary
 @Service
 class PlaylistServiceCacheImpl(
     private val impl: PlaylistServiceImpl,
 ) : PlaylistService {
+    
+    private val playlistGroupsCache: SimpleCache<String, List<PlaylistGroup>> = SimpleCache()
+    
+    private val playlistCache: SimpleCache<Long, Playlist> = SimpleCache()
 
     override fun getGroups(): List<PlaylistGroup> {
-        TODO("Not yet implemented")
+        return playlistGroupsCache.get("playlistGroups") {
+            impl.getGroups()
+        }
     }
 
     override fun get(id: Long): Playlist {
-        TODO("Not yet implemented")
+        return playlistCache.get(id) {
+            impl.get(id)
+        }
     }
+    
 }

--- a/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.seminar.spring2023.playlist.service
 
 import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistGroupRepository
 import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistRepository
-import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistSongsEntity
 import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
@@ -22,10 +21,8 @@ class PlaylistServiceImpl(
 
     override fun get(id: Long): Playlist {
         val playlist = playlistRepository.findByIdWithJoinFetch(id) ?: throw PlaylistNotFoundException()
-        val songs = songRepository.findBySongsWithJoinFetch(playlist.songs.map { it.song.id }) // 향후 약간 수정 필요 테스트는 통과했음.
-        playlist.songs.clear()
-        playlist.songs.addAll(songs.map { PlaylistSongsEntity(it.id, playlist, it) })
-        return Playlist(playlist)
+        val songs = songRepository.findBySongsWithJoinFetch(playlist.songs.map { it.song.id })
+        return Playlist(playlist, songs)
     }
 
 }

--- a/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
@@ -1,17 +1,31 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistGroupRepository
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistRepository
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistSongsEntity
+import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 
 @Primary
 @Service
-class PlaylistServiceImpl : PlaylistService {
+class PlaylistServiceImpl(
+    private val playlistRepository: PlaylistRepository,
+    private val songRepository: SongRepository,
+    private val playlistGroupRepository: PlaylistGroupRepository,
+) : PlaylistService {
 
     override fun getGroups(): List<PlaylistGroup> {
-        TODO()
+        return playlistGroupRepository.findAllWithJoinFetch()
+            .map { PlaylistGroup(it) }
     }
 
     override fun get(id: Long): Playlist {
-        TODO()
+        val playlist = playlistRepository.findByIdWithJoinFetch(id) ?: throw PlaylistNotFoundException()
+        val songs = songRepository.findBySongsWithJoinFetch(playlist.songs.map { it.song.id }) // 향후 약간 수정 필요 테스트는 통과했음.
+        playlist.songs.clear()
+        playlist.songs.addAll(songs.map { PlaylistSongsEntity(it.id, playlist, it) })
+        return Playlist(playlist)
     }
+
 }

--- a/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
@@ -3,10 +3,8 @@ package com.wafflestudio.seminar.spring2023.playlist.service
 import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistGroupRepository
 import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistRepository
 import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
-import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 
-@Primary
 @Service
 class PlaylistServiceImpl(
     private val playlistRepository: PlaylistRepository,

--- a/src/main/kotlin/song/controller/SongController.kt
+++ b/src/main/kotlin/song/controller/SongController.kt
@@ -8,21 +8,24 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class SongController {
+class SongController(
+    private val songService: SongService,
+) {
 
     @GetMapping("/api/v1/songs")
     fun searchSong(
         @RequestParam keyword: String,
     ): SearchSongResponse {
-        TODO()
+        return SearchSongResponse(songService.search(keyword))
     }
 
     @GetMapping("/api/v1/albums")
     fun searchAlbum(
         @RequestParam keyword: String,
     ): SearchAlbumResponse {
-        TODO()
+        return SearchAlbumResponse(songService.searchAlbum(keyword))
     }
+
 }
 
 data class SearchSongResponse(

--- a/src/main/kotlin/song/repository/AlbumRepository.kt
+++ b/src/main/kotlin/song/repository/AlbumRepository.kt
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface AlbumRepository : JpaRepository<AlbumEntity, Long> {
+    
     @Query("SELECT a FROM albums a LEFT JOIN FETCH a.artist WHERE a.title LIKE :keyword ORDER BY LENGTH(a.title) ")
     fun searchWithJoinFetch(keyword: String): List<AlbumEntity>
+    
 }

--- a/src/main/kotlin/song/repository/AlbumRepository.kt
+++ b/src/main/kotlin/song/repository/AlbumRepository.kt
@@ -1,5 +1,9 @@
 package com.wafflestudio.seminar.spring2023.song.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface AlbumRepository : JpaRepository<AlbumEntity, Long>
+interface AlbumRepository : JpaRepository<AlbumEntity, Long> {
+    @Query("SELECT a FROM albums a LEFT JOIN FETCH a.artist WHERE a.title LIKE :keyword ORDER BY LENGTH(a.title) ")
+    fun searchWithJoinFetch(keyword: String): List<AlbumEntity>
+}

--- a/src/main/kotlin/song/repository/AlbumRepository.kt
+++ b/src/main/kotlin/song/repository/AlbumRepository.kt
@@ -4,8 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface AlbumRepository : JpaRepository<AlbumEntity, Long> {
-    
-    @Query("SELECT a FROM albums a LEFT JOIN FETCH a.artist WHERE a.title LIKE :keyword ORDER BY LENGTH(a.title) ")
+
+    @Query("SELECT a FROM albums a LEFT JOIN FETCH a.artist WHERE a.title LIKE :keyword ORDER BY LENGTH(a.title)")
     fun searchWithJoinFetch(keyword: String): List<AlbumEntity>
-    
+
 }

--- a/src/main/kotlin/song/repository/ArtistEntity.kt
+++ b/src/main/kotlin/song/repository/ArtistEntity.kt
@@ -1,10 +1,6 @@
 package com.wafflestudio.seminar.spring2023.song.repository
 
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.OneToMany
+import jakarta.persistence.*
 
 @Entity(name = "artists")
 class ArtistEntity(

--- a/src/main/kotlin/song/repository/SongArtistsEntity.kt
+++ b/src/main/kotlin/song/repository/SongArtistsEntity.kt
@@ -2,16 +2,15 @@ package com.wafflestudio.seminar.spring2023.song.repository
 
 import jakarta.persistence.*
 
-@Entity(name = "albums")
-class AlbumEntity(
+@Entity(name = "song_artists")
+class SongArtistsEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    val title: String,
-    val image: String,
-    @ManyToOne // default FetchType.EAGER
+    @ManyToOne
+    @JoinColumn(name = "song_id")
+    val song2: SongEntity,
+    @ManyToOne
     @JoinColumn(name = "artist_id")
     val artist: ArtistEntity,
-    @OneToMany(mappedBy = "album")
-    val songs: List<SongEntity>,
 )

--- a/src/main/kotlin/song/repository/SongArtistsEntity.kt
+++ b/src/main/kotlin/song/repository/SongArtistsEntity.kt
@@ -9,7 +9,7 @@ class SongArtistsEntity(
     val id: Long = 0L,
     @ManyToOne
     @JoinColumn(name = "song_id")
-    val song2: SongEntity,
+    val song: SongEntity,
     @ManyToOne
     @JoinColumn(name = "artist_id")
     val artist: ArtistEntity,

--- a/src/main/kotlin/song/repository/SongEntity.kt
+++ b/src/main/kotlin/song/repository/SongEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.seminar.spring2023.song.repository
+
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistSongsEntity
+import jakarta.persistence.*
+
+@Entity(name = "songs")
+class SongEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val title: String,
+    val duration: Int,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id")
+    val album: AlbumEntity,
+    @OneToMany(mappedBy = "song2")
+    val artists: List<SongArtistsEntity>,
+    @OneToMany(mappedBy = "song")
+    val playlists: List<PlaylistSongsEntity>
+)

--- a/src/main/kotlin/song/repository/SongEntity.kt
+++ b/src/main/kotlin/song/repository/SongEntity.kt
@@ -13,7 +13,7 @@ class SongEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "album_id")
     val album: AlbumEntity,
-    @OneToMany(mappedBy = "song2")
+    @OneToMany(mappedBy = "song")
     val artists: List<SongArtistsEntity>,
     @OneToMany(mappedBy = "song")
     val playlists: List<PlaylistSongsEntity>

--- a/src/main/kotlin/song/repository/SongRepository.kt
+++ b/src/main/kotlin/song/repository/SongRepository.kt
@@ -4,10 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface SongRepository : JpaRepository<SongEntity, Long> {
+    
     @Query("SELECT DISTINCT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.id IN :songs")
     fun findBySongsWithJoinFetch(songs: List<Long>): List<SongEntity>
 
     @Query("SELECT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.title LIKE :keyword ORDER BY LENGTH(s.title)")
     fun searchWithJoinFetch(keyword: String): List<SongEntity>
-
+    
 }

--- a/src/main/kotlin/song/repository/SongRepository.kt
+++ b/src/main/kotlin/song/repository/SongRepository.kt
@@ -4,11 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface SongRepository : JpaRepository<SongEntity, Long> {
-    
-    @Query("SELECT DISTINCT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.id IN :songs")
+
+    @Query("SELECT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.id IN :songs")
     fun findBySongsWithJoinFetch(songs: List<Long>): List<SongEntity>
 
     @Query("SELECT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.title LIKE :keyword ORDER BY LENGTH(s.title)")
     fun searchWithJoinFetch(keyword: String): List<SongEntity>
-    
+
 }

--- a/src/main/kotlin/song/repository/SongRepository.kt
+++ b/src/main/kotlin/song/repository/SongRepository.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.seminar.spring2023.song.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface SongRepository : JpaRepository<SongEntity, Long> {
+    @Query("SELECT DISTINCT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.id IN :songs")
+    fun findBySongsWithJoinFetch(songs: List<Long>): List<SongEntity>
+
+    @Query("SELECT s FROM songs s LEFT JOIN FETCH s.album al LEFT JOIN FETCH s.artists sa LEFT JOIN FETCH sa.artist a WHERE s.title LIKE :keyword ORDER BY LENGTH(s.title)")
+    fun searchWithJoinFetch(keyword: String): List<SongEntity>
+
+}

--- a/src/main/kotlin/song/service/Album.kt
+++ b/src/main/kotlin/song/service/Album.kt
@@ -1,8 +1,17 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.AlbumEntity
+
 data class Album(
     val id: Long,
     val title: String,
     val image: String,
     val artist: Artist,
+)
+
+fun AlbumEntity.toAlbum() = Album(
+    id = id,
+    title = title,
+    image = image,
+    artist = artist.toArtist()
 )

--- a/src/main/kotlin/song/service/Artist.kt
+++ b/src/main/kotlin/song/service/Artist.kt
@@ -1,6 +1,13 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.ArtistEntity
+
 data class Artist(
     val id: Long,
     val name: String,
+)
+
+fun ArtistEntity.toArtist() = Artist(
+    id = id,
+    name = name
 )

--- a/src/main/kotlin/song/service/Song.kt
+++ b/src/main/kotlin/song/service/Song.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
+
 data class Song(
     val id: Long,
     val title: String,
@@ -7,4 +9,13 @@ data class Song(
     val album: String,
     val image: String,
     val duration: String,
+)
+
+fun SongEntity.toSong(): Song = Song(
+    id = id,
+    title = title,
+    artists = artists.map { it.artist.toArtist() },
+    image = album.image,
+    album = album.title,
+    duration = "${duration / 60}:${String.format("%02d", duration % 60)}",
 )

--- a/src/main/kotlin/song/service/SongServiceImpl.kt
+++ b/src/main/kotlin/song/service/SongServiceImpl.kt
@@ -1,15 +1,24 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.AlbumRepository
+import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
 import org.springframework.stereotype.Service
 
 @Service
-class SongServiceImpl : SongService {
+class SongServiceImpl(
+    private val songRepository: SongRepository,
+    private val albumRepository: AlbumRepository,
+) : SongService {
 
     override fun search(keyword: String): List<Song> {
-        TODO()
+        return songRepository.searchWithJoinFetch("%$keyword%").map {
+            it.toSong()
+        }
     }
 
     override fun searchAlbum(keyword: String): List<Album> {
-        TODO()
+        return albumRepository.searchWithJoinFetch("%$keyword%").map {
+            it.toAlbum()
+        }
     }
 }

--- a/src/main/kotlin/song/service/SongServiceImpl.kt
+++ b/src/main/kotlin/song/service/SongServiceImpl.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.AlbumEntity
 import com.wafflestudio.seminar.spring2023.song.repository.AlbumRepository
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
 import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
 import org.springframework.stereotype.Service
 
@@ -11,14 +13,11 @@ class SongServiceImpl(
 ) : SongService {
 
     override fun search(keyword: String): List<Song> {
-        return songRepository.searchWithJoinFetch("%$keyword%").map {
-            it.toSong()
-        }
+        return songRepository.searchWithJoinFetch("%$keyword%").map(SongEntity::toSong)
     }
 
     override fun searchAlbum(keyword: String): List<Album> {
-        return albumRepository.searchWithJoinFetch("%$keyword%").map {
-            it.toAlbum()
-        }
+        return albumRepository.searchWithJoinFetch("%$keyword%").map(AlbumEntity::toAlbum)
     }
+   
 }

--- a/src/main/kotlin/user/controller/UserController.kt
+++ b/src/main/kotlin/user/controller/UserController.kt
@@ -1,17 +1,8 @@
 package com.wafflestudio.seminar.spring2023.user.controller
 
-import com.wafflestudio.seminar.spring2023.user.service.AuthenticateException
 import com.wafflestudio.seminar.spring2023.user.service.Authenticated
-import com.wafflestudio.seminar.spring2023.user.service.SignInInvalidPasswordException
-import com.wafflestudio.seminar.spring2023.user.service.SignInUserNotFoundException
-import com.wafflestudio.seminar.spring2023.user.service.SignUpBadPasswordException
-import com.wafflestudio.seminar.spring2023.user.service.SignUpBadUsernameException
-import com.wafflestudio.seminar.spring2023.user.service.SignUpUsernameConflictException
 import com.wafflestudio.seminar.spring2023.user.service.User
-import com.wafflestudio.seminar.spring2023.user.service.UserException
 import com.wafflestudio.seminar.spring2023.user.service.UserService
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -55,17 +46,6 @@ class UserController(
         )
     }
 
-    @ExceptionHandler
-    fun handleException(e: UserException): ResponseEntity<Unit> {
-        val status = when (e) {
-            is SignUpBadUsernameException, is SignUpBadPasswordException -> 400
-            is SignUpUsernameConflictException -> 409
-            is SignInUserNotFoundException, is SignInInvalidPasswordException -> 404
-            is AuthenticateException -> 401
-        }
-
-        return ResponseEntity.status(status).build()
-    }
 }
 
 data class UserMeResponse(

--- a/src/main/kotlin/user/repository/UserEntity.kt
+++ b/src/main/kotlin/user/repository/UserEntity.kt
@@ -1,9 +1,7 @@
 package com.wafflestudio.seminar.spring2023.user.repository
 
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistLikesEntity
+import jakarta.persistence.*
 
 @Entity(name = "users")
 class UserEntity(
@@ -13,4 +11,6 @@ class UserEntity(
     val username: String,
     val password: String,
     val image: String,
+    @OneToMany(mappedBy = "user")
+    val playlistLikes: List<PlaylistLikesEntity> = emptyList(),
 )

--- a/src/test/kotlin/playlist/PlaylistIntegrationTest.kt
+++ b/src/test/kotlin/playlist/PlaylistIntegrationTest.kt
@@ -1,13 +1,89 @@
 package com.wafflestudio.seminar.spring2023.playlist
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class PlaylistIntegrationTest @Autowired constructor(
     private val mvc: MockMvc,
+    private val mapper: ObjectMapper,
 ) {
+
+    @Test
+    fun `플레이리스트 그룹 조회`() {
+        mvc.perform(
+            get("/api/v1/playlist-groups")
+        ).andExpect(status().`is`(200))
+    }
+
+    @Test
+    fun `플레이스트 조회 실패시 404 응답 내려준다`() {
+        mvc.perform(
+            get("/api/v1/playlists/1")
+        ).andExpect(status().`is`(200))
+
+        // playlist doesn't exist
+        mvc.perform(
+            get("/api/v1/playlist/300")
+        ).andExpect(status().`is`(404))
+    }
+
+    @Test
+    fun `비로그인 상황, Like, UnLike 요청시 401 응답 내려준다`() {
+        mvc.perform(
+            post("/api/v1/playlists/1/likes")
+        ).andExpect(status().`is`(401))
+    }
+
+    @Test
+    fun `로그인 상황, 플레이리스트 Like, UnLike 중복 요청시 403 응답 내려준다`() {
+        // 회원 가입
+        mvc.perform(
+            post("/api/v1/signup")
+                .content(
+                    mapper.writeValueAsString(
+                        mapOf(
+                            "username" to "test-${javaClass.name}-2",
+                            "password" to "correct",
+                            "image" to "https://wafflestudio.com/images/icon_intro.svg"
+                        )
+                    )
+                )
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().`is`(200))
+
+        // Unlike Playlist에 unLike 요청
+        mvc.perform(
+            delete("/api/v1/playlists/1/likes")
+                .header("Authorization", "Bearer ${"test-${javaClass.name}-2".reversed()}")
+        ).andExpect(status().`is`(403))
+
+        // Unlike Playlist에 Like 요청
+        mvc.perform(
+            post("/api/v1/playlists/1/likes")
+                .header("Authorization", "Bearer ${"test-${javaClass.name}-2".reversed()}")
+        ).andExpect(status().`is`(200))
+
+        // Like Playlist에 Like 요청
+        mvc.perform(
+            post("/api/v1/playlists/1/likes")
+                .header("Authorization", "Bearer ${"test-${javaClass.name}-2".reversed()}")
+        ).andExpect(status().`is`(403))
+
+        // Like Playlist에 Unlike 요청
+        mvc.perform(
+            delete("/api/v1/playlists/1/likes")
+                .header("Authorization", "Bearer ${"test-${javaClass.name}-2".reversed()}")
+        ).andExpect(status().`is`(200))
+    }
+
 }

--- a/src/test/kotlin/song/SongIntegrationTest.kt
+++ b/src/test/kotlin/song/SongIntegrationTest.kt
@@ -1,13 +1,31 @@
 package com.wafflestudio.seminar.spring2023.song
 
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class SongIntegrationTest @Autowired constructor(
     private val mvc: MockMvc,
 ) {
+
+    @Test
+    fun `노래 조회`() {
+        mvc.perform(
+            get("/api/v1/songs?keyword=Seven")
+        ).andExpect(status().`is`(200))
+    }
+
+    @Test
+    fun `앨범 조회`() {
+        mvc.perform(
+            get("/api/v1/albums?keyword=Seven")
+        ).andExpect(status().`is`(200))
+    }
+    
 }


### PR DESCRIPTION
1주차 과제와 캐시 구현 추가 과제 제출합니다.

 다음은 특이사항입니다. 리뷰시 참고하시면 좋을 것 같습니다.

1. UserException의 경우는 PlaylistController에도 해당 Exception이 발생하여 Global ExceptionHandler로 처리하였습니다.
2. `PlaylistIntegrationTest`에서 각 테스트마다 `회원 가입` 메소드가 실행되도록 `@BeforeEach`를 사용하였고 해당 테스트 클래스에 `@Transactional` 어노테이션을 붙여 중복 회원가입을 막았습니다.
3. 엔티티와 DTO 사이 매핑은 생성자와 변환 함수(`toSong` 등)을 혼용하여 사용하였습니다. 어떤 것이 더 적합한지 궁금합니다.
4. 캐시의 경우 `common` 패키지에 `SimpleCache`를 이용합니다. `SimpleCache`는 메모리 저장을 위해 HashMap을 사용하였습니다. 캐시가 미스된 경우 block이 실행되도록 구현하여 가독성을 증진시켜 보았습니다.

좋은 과제 제공해주셔서 감사합니다!