### PR TITLE
송동엽 seminar1 과제 [청강]

### DIFF
--- a/src/main/kotlin/playlist/controller/PlaylistController.kt
+++ b/src/main/kotlin/playlist/controller/PlaylistController.kt
@@ -1,10 +1,10 @@
 package com.wafflestudio.seminar.spring2023.playlist.controller
 
-import com.wafflestudio.seminar.spring2023.playlist.service.Playlist
-import com.wafflestudio.seminar.spring2023.playlist.service.PlaylistException
-import com.wafflestudio.seminar.spring2023.playlist.service.PlaylistGroup
+import com.wafflestudio.seminar.spring2023.playlist.service.*
+import com.wafflestudio.seminar.spring2023.user.service.AuthenticateException
 import com.wafflestudio.seminar.spring2023.user.service.Authenticated
 import com.wafflestudio.seminar.spring2023.user.service.User
+import com.wafflestudio.seminar.spring2023.user.service.UserException
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -14,11 +14,14 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class PlaylistController {
+class PlaylistController(
+    private val playlistService: PlaylistService,
+    private val playlistLikeService: PlaylistLikeService,
+) {
 
     @GetMapping("/api/v1/playlist-groups")
     fun getPlaylistGroup(): PlaylistGroupsResponse {
-        TODO()
+        return PlaylistGroupsResponse(playlistService.getGroups())
     }
 
     @GetMapping("/api/v1/playlists/{id}")
@@ -26,7 +29,10 @@ class PlaylistController {
         @PathVariable id: Long,
         user: User?,
     ): PlaylistResponse {
-        TODO()
+        return PlaylistResponse(
+            playlist = playlistService.get(id),
+            isLiked = user?.let { playlistLikeService.exists(id, it.id) } ?: false
+        )
     }
 
     @PostMapping("/api/v1/playlists/{id}/likes")
@@ -34,7 +40,7 @@ class PlaylistController {
         @PathVariable id: Long,
         @Authenticated user: User,
     ) {
-        TODO()
+        playlistLikeService.create(id, user.id)
     }
 
     @DeleteMapping("/api/v1/playlists/{id}/likes")
@@ -42,12 +48,27 @@ class PlaylistController {
         @PathVariable id: Long,
         @Authenticated user: User,
     ) {
-        TODO()
+        playlistLikeService.delete(id, user.id)
+    }
+
+    @ExceptionHandler
+    fun handleException(e: UserException): ResponseEntity<Unit> {
+        val status = when(e) {
+            is AuthenticateException -> 401
+            else -> 400
+        }
+
+        return ResponseEntity.status(status).build()
     }
 
     @ExceptionHandler
     fun handleException(e: PlaylistException): ResponseEntity<Unit> {
-        TODO()
+        val status = when (e) {
+            is PlaylistNotFoundException -> 404
+            is PlaylistAlreadyLikedException, is PlaylistNeverLikedException -> 409
+        }
+
+        return ResponseEntity.status(status).build()
     }
 }
 

--- a/src/main/kotlin/playlist/repository/PlaylistEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistEntity.kt
@@ -10,7 +10,7 @@ class PlaylistEntity(
     val title: String,
     val subtitle: String,
     val image: String,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     val group: PlaylistGroupEntity,
     @OneToMany(mappedBy = "playlist")

--- a/src/main/kotlin/playlist/repository/PlaylistEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import jakarta.persistence.*
+
+@Entity(name = "playlists")
+class PlaylistEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val title: String,
+    val subtitle: String,
+    val image: String,
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    val group: PlaylistGroupEntity,
+    @OneToMany(mappedBy = "playlist")
+    val likeUsers: List<PlaylistLikesEntity>,
+    @OneToMany(mappedBy = "playlist")
+    val songs: List<PlaylistSongEntity>,
+)

--- a/src/main/kotlin/playlist/repository/PlaylistGroupEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistGroupEntity.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import jakarta.persistence.*
+
+@Entity(name = "playlist_groups")
+class PlaylistGroupEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val title: String,
+    val open: Boolean,
+    @OneToMany(mappedBy = "group")
+    val playlists: List<PlaylistEntity>,
+)

--- a/src/main/kotlin/playlist/repository/PlaylistGroupRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistGroupRepository.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface PlaylistGroupRepository: JpaRepository<PlaylistGroupEntity, Long> {
+    @Query("select a from playlist_groups a inner join fetch a.playlists where a.open = :open")
+    fun findNotEmptyGroupsByOpen(open: Boolean): List<PlaylistGroupEntity>
+}

--- a/src/main/kotlin/playlist/repository/PlaylistLikesEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistLikesEntity.kt
@@ -9,10 +9,10 @@ class PlaylistLikesEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "playlist_id")
     val playlist: PlaylistEntity,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val user: UserEntity,
 )

--- a/src/main/kotlin/playlist/repository/PlaylistLikesEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistLikesEntity.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import com.wafflestudio.seminar.spring2023.playlist.service.Playlist
+import com.wafflestudio.seminar.spring2023.user.repository.UserEntity
+import jakarta.persistence.*
+
+@Entity(name = "playlist_likes")
+class PlaylistLikesEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @ManyToOne
+    @JoinColumn(name = "playlist_id")
+    val playlist: PlaylistEntity,
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    val user: UserEntity,
+)

--- a/src/main/kotlin/playlist/repository/PlaylistLikesRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistLikesRepository.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface PlaylistLikesRepository: JpaRepository<PlaylistLikesEntity, Long> {
+    @Query("select count(pl.id) > 0 from playlist_likes pl where pl.playlist.id=:playlistId and pl.user.id=:userId")
+    fun existsByPlaylistIdAndUserId(playlistId: Long, userId: Long): Boolean
+
+    @Query("select pl from playlist_likes pl where pl.playlist.id=:playlistId and pl.user.id=:userId")
+    fun findByPlaylistIdAndUserId(playlistId: Long, userId: Long): PlaylistLikesEntity?
+}

--- a/src/main/kotlin/playlist/repository/PlaylistRepository.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistRepository.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface PlaylistRepository : JpaRepository<PlaylistEntity, Long> {
+    @Query("""
+        select p from playlists p
+        left join fetch p.songs ps
+        join fetch ps.song s
+        where p.id = :id
+    """)
+    fun findByIdWithJoinFetch(id: Long): PlaylistEntity?
+}

--- a/src/main/kotlin/playlist/repository/PlaylistSongEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistSongEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.seminar.spring2023.playlist.repository
+
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
+import jakarta.persistence.*
+
+@Entity(name = "playlist_songs")
+class PlaylistSongEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @ManyToOne
+    @JoinColumn(name = "playlist_id")
+    val playlist: PlaylistEntity,
+    @ManyToOne
+    @JoinColumn(name = "song_id")
+    val song: SongEntity,
+)

--- a/src/main/kotlin/playlist/repository/PlaylistSongEntity.kt
+++ b/src/main/kotlin/playlist/repository/PlaylistSongEntity.kt
@@ -8,10 +8,10 @@ class PlaylistSongEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "playlist_id")
     val playlist: PlaylistEntity,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "song_id")
     val song: SongEntity,
 )

--- a/src/main/kotlin/playlist/service/Playlist.kt
+++ b/src/main/kotlin/playlist/service/Playlist.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistEntity
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
 import com.wafflestudio.seminar.spring2023.song.service.Song
 
 data class Playlist(
@@ -8,4 +10,14 @@ data class Playlist(
     val subtitle: String,
     val image: String,
     val songs: List<Song>,
-)
+) {
+    constructor(playlistEntity: PlaylistEntity, songEntities: List<SongEntity>): this(
+        id = playlistEntity.id,
+        title = playlistEntity.title,
+        subtitle = playlistEntity.title,
+        image = playlistEntity.image,
+        songs = songEntities.map {
+            Song(it)
+        }.sortedBy { it.id }
+    )
+}

--- a/src/main/kotlin/playlist/service/PlaylistBrief.kt
+++ b/src/main/kotlin/playlist/service/PlaylistBrief.kt
@@ -1,8 +1,17 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistEntity
+
 data class PlaylistBrief(
     val id: Long,
     val title: String,
     val subtitle: String,
     val image: String,
-)
+) {
+    constructor(entity: PlaylistEntity): this(
+        id = entity.id,
+        title = entity.title,
+        subtitle = entity.subtitle,
+        image = entity.image
+    )
+}

--- a/src/main/kotlin/playlist/service/PlaylistGroup.kt
+++ b/src/main/kotlin/playlist/service/PlaylistGroup.kt
@@ -1,7 +1,17 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistGroupEntity
+
 data class PlaylistGroup(
     val id: Long,
     val title: String,
     val playlists: List<PlaylistBrief>,
-)
+) {
+    constructor(entity: PlaylistGroupEntity): this(
+        id = entity.id,
+        title = entity.title,
+        playlists = entity.playlists.map {
+            PlaylistBrief(it)
+        }
+    )
+}

--- a/src/main/kotlin/playlist/service/PlaylistLikeServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistLikeServiceImpl.kt
@@ -1,19 +1,44 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistLikesEntity
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistLikesRepository
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistRepository
+import com.wafflestudio.seminar.spring2023.user.repository.UserRepository
+import com.wafflestudio.seminar.spring2023.user.service.UserNotFoundException
 import org.springframework.stereotype.Service
 
 @Service
-class PlaylistLikeServiceImpl : PlaylistLikeService {
+class PlaylistLikeServiceImpl(
+    val playlistLikesRepository: PlaylistLikesRepository,
+    val playlistRepository: PlaylistRepository,
+    val userRepository: UserRepository,
+) : PlaylistLikeService {
 
     override fun exists(playlistId: Long, userId: Long): Boolean {
-        TODO()
+        return playlistLikesRepository.existsByPlaylistIdAndUserId(playlistId, userId)
     }
 
     override fun create(playlistId: Long, userId: Long) {
-        TODO()
+        if (exists(playlistId, userId)) throw PlaylistAlreadyLikedException()
+        val playlistEntity = playlistRepository.findById(playlistId).orElseThrow {
+            PlaylistNotFoundException()
+        }
+        val userEntity = userRepository.findById(userId).orElseThrow {
+            UserNotFoundException()
+        }
+        playlistLikesRepository.save(
+            PlaylistLikesEntity(
+                playlist = playlistEntity,
+                    user = userEntity,
+            )
+        )
     }
 
     override fun delete(playlistId: Long, userId: Long) {
-        TODO()
+        val playlistLikesEntity = playlistLikesRepository.findByPlaylistIdAndUserId(playlistId, userId)
+                ?: throw PlaylistNeverLikedException()
+        playlistLikesRepository.delete(
+                playlistLikesEntity
+        )
     }
 }

--- a/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
+++ b/src/main/kotlin/playlist/service/PlaylistServiceImpl.kt
@@ -1,17 +1,27 @@
 package com.wafflestudio.seminar.spring2023.playlist.service
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.*
+import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 
 @Primary
 @Service
-class PlaylistServiceImpl : PlaylistService {
+class PlaylistServiceImpl(
+    val playlistGroupRepository: PlaylistGroupRepository,
+    val playlistRepository: PlaylistRepository,
+    val songRepository: SongRepository,
+) : PlaylistService {
 
     override fun getGroups(): List<PlaylistGroup> {
-        TODO()
+        return playlistGroupRepository.findNotEmptyGroupsByOpen(true).map {
+            PlaylistGroup(it)
+        }
     }
 
     override fun get(id: Long): Playlist {
-        TODO()
+        val playlistEntity = playlistRepository.findByIdWithJoinFetch(id) ?: throw PlaylistNotFoundException()
+        val songEntities = songRepository.findByIdsWithJoinFetch(playlistEntity.songs.map { it.song.id })
+        return Playlist(playlistEntity, songEntities)
     }
 }

--- a/src/main/kotlin/song/controller/SongController.kt
+++ b/src/main/kotlin/song/controller/SongController.kt
@@ -8,20 +8,22 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class SongController {
+class SongController(
+    private val songService: SongService
+) {
 
     @GetMapping("/api/v1/songs")
     fun searchSong(
         @RequestParam keyword: String,
     ): SearchSongResponse {
-        TODO()
+        return SearchSongResponse(songService.search(keyword))
     }
 
     @GetMapping("/api/v1/albums")
     fun searchAlbum(
         @RequestParam keyword: String,
     ): SearchAlbumResponse {
-        TODO()
+        return SearchAlbumResponse(songService.searchAlbum(keyword))
     }
 }
 

--- a/src/main/kotlin/song/repository/AlbumRepository.kt
+++ b/src/main/kotlin/song/repository/AlbumRepository.kt
@@ -1,5 +1,13 @@
 package com.wafflestudio.seminar.spring2023.song.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface AlbumRepository : JpaRepository<AlbumEntity, Long>
+interface AlbumRepository : JpaRepository<AlbumEntity, Long> {
+    @Query("""
+        select a from albums a
+        join fetch a.artist ar
+        where a.title like %:keyword% order by length(a.title) asc
+    """)
+    fun findAllByTitleKeywordWithJoinFetch(keyword: String): List<AlbumEntity>
+}

--- a/src/main/kotlin/song/repository/ArtistEntity.kt
+++ b/src/main/kotlin/song/repository/ArtistEntity.kt
@@ -1,10 +1,6 @@
 package com.wafflestudio.seminar.spring2023.song.repository
 
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.OneToMany
+import jakarta.persistence.*
 
 @Entity(name = "artists")
 class ArtistEntity(
@@ -14,4 +10,6 @@ class ArtistEntity(
     val name: String,
     @OneToMany(mappedBy = "artist")
     val albums: List<AlbumEntity>,
+    @OneToMany(mappedBy = "artist")
+    val songs: List<SongArtistEntity>,
 )

--- a/src/main/kotlin/song/repository/SongArtistEntity.kt
+++ b/src/main/kotlin/song/repository/SongArtistEntity.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.seminar.spring2023.song.repository
+
+import jakarta.persistence.*
+
+@Entity(name = "song_artists")
+class SongArtistEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @ManyToOne
+    @JoinColumn(name = "song_id")
+    val song: SongEntity,
+    @ManyToOne
+    @JoinColumn(name = "artist_id")
+    val artist: ArtistEntity,
+)

--- a/src/main/kotlin/song/repository/SongEntity.kt
+++ b/src/main/kotlin/song/repository/SongEntity.kt
@@ -10,7 +10,7 @@ class SongEntity (
     val id: Long = 0L,
     val title: String,
     val duration: String,
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "album_id")
     val album: AlbumEntity,
     @OneToMany(mappedBy = "song")

--- a/src/main/kotlin/song/repository/SongEntity.kt
+++ b/src/main/kotlin/song/repository/SongEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.seminar.spring2023.song.repository
+
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistSongEntity
+import jakarta.persistence.*
+
+@Entity(name = "songs")
+class SongEntity (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    val title: String,
+    val duration: String,
+    @ManyToOne
+    @JoinColumn(name = "album_id")
+    val album: AlbumEntity,
+    @OneToMany(mappedBy = "song")
+    val artists: List<SongArtistEntity>,
+    @OneToMany(mappedBy = "song")
+    val playlists: List<PlaylistSongEntity>,
+)

--- a/src/main/kotlin/song/repository/SongRepository.kt
+++ b/src/main/kotlin/song/repository/SongRepository.kt
@@ -12,4 +12,14 @@ interface SongRepository: JpaRepository<SongEntity, Long> {
         where s.id in :ids
     """)
     fun findByIdsWithJoinFetch(ids: List<Long>): List<SongEntity>
+
+    @Query("""
+        select s from songs s
+        join fetch s.album al
+        join fetch s.artists sa
+        join fetch sa.artist
+        where s.title like %:keyword%
+        order by length(s.title) asc
+    """)
+    fun findAllByTitleKeywordWithJoinFetch(keyword: String): List<SongEntity>
 }

--- a/src/main/kotlin/song/repository/SongRepository.kt
+++ b/src/main/kotlin/song/repository/SongRepository.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.seminar.spring2023.song.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface SongRepository: JpaRepository<SongEntity, Long> {
+    @Query("""
+        select s from songs s
+        join fetch s.album al
+        join fetch s.artists sa
+        join fetch sa.artist
+        where s.id in :ids
+    """)
+    fun findByIdsWithJoinFetch(ids: List<Long>): List<SongEntity>
+}

--- a/src/main/kotlin/song/service/Album.kt
+++ b/src/main/kotlin/song/service/Album.kt
@@ -1,8 +1,17 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.AlbumEntity
+
 data class Album(
     val id: Long,
     val title: String,
     val image: String,
     val artist: Artist,
-)
+) {
+    constructor(entity: AlbumEntity): this(
+        id = entity.id,
+        title = entity.title,
+        image = entity.image,
+        artist = Artist(entity.artist)
+    )
+}

--- a/src/main/kotlin/song/service/Artist.kt
+++ b/src/main/kotlin/song/service/Artist.kt
@@ -1,6 +1,13 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.ArtistEntity
+
 data class Artist(
     val id: Long,
     val name: String,
-)
+) {
+    constructor(entity: ArtistEntity): this(
+        id = entity.id,
+        name = entity.name,
+    )
+}

--- a/src/main/kotlin/song/service/Song.kt
+++ b/src/main/kotlin/song/service/Song.kt
@@ -1,5 +1,7 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.SongEntity
+
 data class Song(
     val id: Long,
     val title: String,
@@ -7,4 +9,13 @@ data class Song(
     val album: String,
     val image: String,
     val duration: String,
-)
+) {
+    constructor(entity: SongEntity): this(
+        id = entity.id,
+        title = entity.title,
+        artists = entity.artists.map { Artist(it.artist) },
+        album = entity.album.title,
+        image = entity.album.image,
+        duration = entity.duration
+    )
+}

--- a/src/main/kotlin/song/service/SongServiceImpl.kt
+++ b/src/main/kotlin/song/service/SongServiceImpl.kt
@@ -1,15 +1,20 @@
 package com.wafflestudio.seminar.spring2023.song.service
 
+import com.wafflestudio.seminar.spring2023.song.repository.AlbumRepository
+import com.wafflestudio.seminar.spring2023.song.repository.SongRepository
 import org.springframework.stereotype.Service
 
 @Service
-class SongServiceImpl : SongService {
+class SongServiceImpl(
+        val songRepository: SongRepository,
+        val albumRepository: AlbumRepository
+) : SongService {
 
     override fun search(keyword: String): List<Song> {
-        TODO()
+        return songRepository.findAllByTitleKeywordWithJoinFetch(keyword).map { Song(it) }
     }
 
     override fun searchAlbum(keyword: String): List<Album> {
-        TODO()
+        return albumRepository.findAllByTitleKeywordWithJoinFetch(keyword).map { Album(it) }
     }
 }

--- a/src/main/kotlin/user/controller/UserController.kt
+++ b/src/main/kotlin/user/controller/UserController.kt
@@ -1,15 +1,6 @@
 package com.wafflestudio.seminar.spring2023.user.controller
 
-import com.wafflestudio.seminar.spring2023.user.service.AuthenticateException
-import com.wafflestudio.seminar.spring2023.user.service.Authenticated
-import com.wafflestudio.seminar.spring2023.user.service.SignInInvalidPasswordException
-import com.wafflestudio.seminar.spring2023.user.service.SignInUserNotFoundException
-import com.wafflestudio.seminar.spring2023.user.service.SignUpBadPasswordException
-import com.wafflestudio.seminar.spring2023.user.service.SignUpBadUsernameException
-import com.wafflestudio.seminar.spring2023.user.service.SignUpUsernameConflictException
-import com.wafflestudio.seminar.spring2023.user.service.User
-import com.wafflestudio.seminar.spring2023.user.service.UserException
-import com.wafflestudio.seminar.spring2023.user.service.UserService
+import com.wafflestudio.seminar.spring2023.user.service.*
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
@@ -60,7 +51,7 @@ class UserController(
         val status = when (e) {
             is SignUpBadUsernameException, is SignUpBadPasswordException -> 400
             is SignUpUsernameConflictException -> 409
-            is SignInUserNotFoundException, is SignInInvalidPasswordException -> 404
+            is SignInUserNotFoundException, is SignInInvalidPasswordException, is UserNotFoundException -> 404
             is AuthenticateException -> 401
         }
 

--- a/src/main/kotlin/user/repository/UserEntity.kt
+++ b/src/main/kotlin/user/repository/UserEntity.kt
@@ -1,9 +1,11 @@
 package com.wafflestudio.seminar.spring2023.user.repository
 
+import com.wafflestudio.seminar.spring2023.playlist.repository.PlaylistLikesEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 
 @Entity(name = "users")
 class UserEntity(
@@ -13,4 +15,6 @@ class UserEntity(
     val username: String,
     val password: String,
     val image: String,
+    @OneToMany(mappedBy = "user")
+    val likePlaylists: List<PlaylistLikesEntity>
 )

--- a/src/main/kotlin/user/service/UserException.kt
+++ b/src/main/kotlin/user/service/UserException.kt
@@ -13,3 +13,5 @@ class SignInUserNotFoundException : UserException()
 class SignInInvalidPasswordException : UserException()
 
 class AuthenticateException : UserException()
+
+class UserNotFoundException: UserException()

--- a/src/main/kotlin/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/user/service/UserServiceImpl.kt
@@ -26,7 +26,8 @@ class UserServiceImpl(
             UserEntity(
                 username = username,
                 password = password,
-                image = image
+                image = image,
+                likePlaylists = emptyList()
             )
         )
 

--- a/src/test/kotlin/playlist/PlaylistIntegrationTest.kt
+++ b/src/test/kotlin/playlist/PlaylistIntegrationTest.kt
@@ -1,13 +1,110 @@
 package com.wafflestudio.seminar.spring2023.playlist
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.transaction.Transactional
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
 class PlaylistIntegrationTest @Autowired constructor(
     private val mvc: MockMvc,
+    private val mapper: ObjectMapper
 ) {
+    @BeforeEach
+    fun 회원가입() {
+        mvc.perform(
+            post("/api/v1/signup")
+                .content(
+                    mapper.writeValueAsString(
+                        mapOf(
+                            "username" to "test",
+                            "password" to "qwer1234",
+                            "image" to "https://wafflestudio.com/images/icon_intro.svg"
+                        )
+                    )
+                )
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().`is`(200))
+    }
+
+    @Test
+    fun `플레이리스트 그룹 조회`() {
+        mvc.perform(
+            get("/api/v1/playlist-groups")
+        ).andExpect(status().`is`(200))
+    }
+
+    @Test
+    fun `플레이리스트 조회`() {
+        mvc.perform(
+            get("/api/v1/playlists/1")
+        ).andExpect(status().`is`(200))
+    }
+
+    @Test
+    fun `존재하지 않는 플레이리스트를 조회한 경우 404`() {
+        mvc.perform(
+            get("/api/v1/playlists/404404404")
+        ).andExpect(status().`is`(404))
+    }
+
+    @Test
+    fun `로그아웃 상태에서 플레이리스트 좋아요 되어있지 않아야 함`() {
+        mvc.perform(
+                get("/api/v1/playlists/1")
+        ).andExpect(jsonPath("$.isLiked").value(false))
+    }
+
+    @Test
+    fun `로그아웃 상태에서 플레이리스트 좋아요 등록 or 해제 시 401`() {
+        mvc.perform(
+            post("/api/v1/playlists/1/likes")
+        ).andExpect(status().`is`(401))
+    }
+
+    @Test
+    fun `로그인 상태에서 플레이리스트 좋아요 등록 or 해제`() {
+        mvc.perform(
+            post("/api/v1/playlists/1/likes")
+                .header("Authorization", "Bearer tset")
+        ).andExpect(status().`is`(200))
+
+        mvc.perform(
+            delete("/api/v1/playlists/1/likes")
+                .header("Authorization", "Bearer tset")
+        ).andExpect(status().`is`(200))
+    }
+
+    @Test
+    fun `로그인 상태에서 플레이리스트 중복 좋아요 등록 or 해제 시 409`() {
+        mvc.perform(
+                post("/api/v1/playlists/1/likes")
+                        .header("Authorization", "Bearer tset")
+        ).andExpect(status().`is`(200))
+
+        mvc.perform(
+                post("/api/v1/playlists/1/likes")
+                        .header("Authorization", "Bearer tset")
+        ).andExpect(status().`is`(409))
+
+        mvc.perform(
+                delete("/api/v1/playlists/1/likes")
+                        .header("Authorization", "Bearer tset")
+        ).andExpect(status().`is`(200))
+
+        mvc.perform(
+                delete("/api/v1/playlists/1/likes")
+                        .header("Authorization", "Bearer tset")
+        ).andExpect(status().`is`(409))
+    }
 }

--- a/src/test/kotlin/song/SongIntegrationTest.kt
+++ b/src/test/kotlin/song/SongIntegrationTest.kt
@@ -1,13 +1,41 @@
 package com.wafflestudio.seminar.spring2023.song
 
+import jakarta.transaction.Transactional
+import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
 class SongIntegrationTest @Autowired constructor(
     private val mvc: MockMvc,
 ) {
+    @Test
+    fun `제목에 키워드를 포함하는 곡 검색`() {
+        mvc.perform(
+            get("/api/v1/songs")
+                .param("keyword", "Shape")
+        )
+            .andExpect(status().`is`(200))
+            .andExpect(jsonPath("$.songs.length()").value(2))
+            .andExpect(jsonPath("$.songs[0].title").value("Shapes"))
+            .andExpect(jsonPath("$.songs[1].title").value("Shape of You"))
+    }
+
+    @Test
+    fun `제목에 키워드를 포함하는 앨범 검색`() {
+        mvc.perform(
+                get("/api/v1/albums")
+                    .param("keyword", "GUT")
+        )
+            .andExpect(status().`is`(200))
+            .andExpect(jsonPath("$.albums.length()").value(1))
+            .andExpect(jsonPath("$.albums[0].title").value("GUTS"))
+    }
 }


### PR DESCRIPTION
좋은 과제 감사합니다! 아래엔 과제하면서 든 질문들을 몇 가지 적어보았습니다.
- `AlbumRepository`의 `findAllByTitleKeywordJoinFetch`에서 `join fetch a.artist ar`을 지우면 쿼리가 4개로 늘어나는데, 이해가 되지 않습니다ㅠㅠ `AlbumEntity`의 `artist`는 `FetchType.EAGER`이기 때문에 `join fetch` 없이 한 번의 쿼리로 `artist`까지 가져올 것이라고 생각했는데 아닌가요? `FetchType.EAGER`는 `artist`를 가져올 시점에만 관련된 것이고, `join fetch`로 쿼리를 줄이는 것은 JPQL으로 따로 해결해야 하는 건가요?
- Entity와 그것의 data class는 가지는 프로퍼티가 동일해야 하나요? `PlaylistEntity`에는 `group: PlaylistGroupEntity`, `likeUsers: List<PlaylistLikesEntity>` 프로퍼티를 추가했지만 `Playlist`에는 추가하지 않았는데, 과제를 하는 데에 문제는 없었습니다. 일반적으로 Entity와 data class의 프로퍼티는 동일하게 하는 것이 좋나요?
- 플레이리스트를 가져올 때 N+1 문제를 피하기 위해 `join fetch`를 사용했는데, `PlaylistEntity`에 OneToMany 관계의 프로퍼티가 2개나 있어서 `MultipleBagFetchException`이 발생했습니다... 다른 분들의 PR과 구글링을 참고하여 songs를 가져오는 쿼리를 따로 분리해 해결했는데, 혹시 더 좋은 방법이 있나요?

감사합니다!